### PR TITLE
Assign font size as an attribute instead of css on <text>

### DIFF
--- a/src/InitialAvatar.php
+++ b/src/InitialAvatar.php
@@ -636,10 +636,10 @@ class InitialAvatar
 		// Text
 		$text = new SVGText( $this->getInitials(), '50%', '50%' );
 		$text->setFont( new SVGFont( $this->getFontName(), $this->findFontFile() ) );
-		$text->setSize( $this->getFontSize() * $this->getWidth() );
 		$text->setStyle( 'line-height', 1 );
 		$text->setAttribute( 'dy', '.1em' );
 		$text->setAttribute( 'fill', $this->getColor() );
+		$text->setAttribute('font-size', $this->getFontSize() * $this->getWidth());		
 		$text->setAttribute( 'text-anchor', 'middle' );
 		$text->setAttribute( 'dominant-baseline', 'middle' );
 


### PR DESCRIPTION
When styling the font-size for the generated SVG using CSS, Firefox has an issue rendering the SVG with the correct font size:

![image](https://user-images.githubusercontent.com/4561584/91583365-1f809580-e91f-11ea-9e2e-208ff91c5b62.png)

This fix adjusts the SVG creation to assign font-size as an attribute instead of a css property resulting in the correct size:

![image](https://user-images.githubusercontent.com/4561584/91583378-24454980-e91f-11ea-88dd-6c4cde387d72.png)

Since the underlying package doesn't assign a unit of measure to the font-size css property, I believe it's technically invalid CSS and Firefox ignores it.

Some discussion around the issue:
adobe-webplatform/Snap.svg/issues/115