### PR TITLE
Update InitialAvatar.php

### DIFF
--- a/src/InitialAvatar.php
+++ b/src/InitialAvatar.php
@@ -674,9 +674,21 @@ class InitialAvatar
 		foreach ( $weightsToTry as $weight ) {
 			$fontFile = preg_replace( '/(\-(Bold|Semibold|Regular))/', "-{$weight}", $originalFile );
 
-			if ( file_exists( $fontFile ) ) {
+			/*
+			  - with php 8.1 AND
+			  - with open_basedir restriction enabled where /fonts/ is not present (is there a linux/unix box where
+			    there is a directory on root level called /fonts/? I do not know any)
+
+			  THEN
+
+			  - the below file_exists check will throw a warning, which is wrong :)
+			*/
+
+			/*
+			  if ( file_exists( $fontFile ) ) {
 				return $fontFile;
-			}
+			  }
+			*/
 
 			if ( file_exists( __DIR__ . $fontFile ) ) {
 				return __DIR__ . $fontFile;


### PR DESCRIPTION
Discovered when porting an existing project to PHP 8.1. 

It seems that with open_basedir restrictions set, a call to file_exists() to any path outside of the paths set in open_basedir setting, a warning will be thrown. Which is not very clean.

also is there a linux/unix box where there is a directory on root level called /fonts/? I do not know any... so commenting this case out :)