### PR TITLE
Fix dynamic property in InitialAvatar (PHP 8.2 deprecation)

### DIFF
--- a/src/InitialAvatar.php
+++ b/src/InitialAvatar.php
@@ -568,7 +568,7 @@ class InitialAvatar
 
 		$translatorClass = array_key_exists( $this->language, $this->translatorMap ) ? $this->translatorMap[ $this->language ] : 'LasseRafn\\InitialAvatarGenerator\\Translator\\En';
 
-		return $this->translato = new $translatorClass();
+		return $this->translator = new $translatorClass();
 	}
 
 	/**


### PR DESCRIPTION
The creation of a dynamic property is deprecated in PHP 8.2, the code throws notices:
```
Creation of dynamic property LasseRafn\InitialAvatarGenerator\InitialAvatar::$translato is deprecated
```

Also this dynamic property does not seem to exist on purpose.