### PR TITLE
IE11 support by adding viewBox

### DIFF
--- a/src/InitialAvatar.php
+++ b/src/InitialAvatar.php
@@ -683,6 +683,7 @@ class InitialAvatar
         // Original document
         $image = new SVG($this->getWidth(), $this->getHeight());
         $document = $image->getDocument();
+        $document->setAttribute('viewBox', "0 0 {$this->getWidth()} {$this->getHeight()}");
 
         // Background
         if ($this->getRounded()) {


### PR DESCRIPTION
Potentially fixes #51 

### Changes

1. Added viewBox attribute to the SVG document in the `makeSvgAvatar()` method
- The viewBox attribute is essential for proper scaling in IE11
- Format is "0 0 width height" which defines the coordinate system
- Uses the same dimensions as the SVG element itself
- This maintains aspect ratio when resizing in IE11