### PR TITLE
Ignore /tests/ directory to smaller package downloads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/tests/             export-ignore
+/demo_result.png    export-ignore


### PR DESCRIPTION
> Using a .gitattributes file function called export-ignore, it is possible to dramatically reduce the file size of a Composer package download.

https://php.watch/articles/composer-gitattributes