### PR TITLE
Update intervention/image to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
         
     runs-on: ubuntu-latest
 

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
 		}
 	],
 	"require": {
-		"php": "^7.0|^7.1|^7.2|^7.3|^7.4|^8.0|^8.1|^8.2",
+		"php": "^8.1",
 		"ext-json": "*",
-		"intervention/image": "^2.3",
+		"intervention/image": "^3.11",
 		"lasserafn/php-initials": "^3.0",
 		"lasserafn/php-string-script-language": "^0.4",
 		"meyfa/php-svg": "^0.9.0",

--- a/src/InitialAvatar.php
+++ b/src/InitialAvatar.php
@@ -85,9 +85,9 @@ class InitialAvatar
         $driver = $this->getDriver();
 
         $driverInstance = match ($driver) {
-            'gd' => new GdDriver(),
+            'gd'      => new GdDriver(),
             'imagick' => new ImagickDriver(),
-            default => throw new RuntimeException("Unsupported driver."),
+            default   => throw new RuntimeException('Unsupported driver.'),
         };
 
         $this->image = new ImageManager($driverInstance);
@@ -714,7 +714,7 @@ class InitialAvatar
                 x: $width / 2,
                 y: $height / 2,
                 init: function (CircleFactory $circle) use ($width, $bgColor) {
-                    $circle->radius($width -2);
+                    $circle->radius($width - 2);
                     $circle->background($bgColor);
                 }
             );
@@ -778,7 +778,6 @@ class InitialAvatar
 
         return $image;
     }
-
 
     /**
      * @return string|null

--- a/src/InitialAvatar.php
+++ b/src/InitialAvatar.php
@@ -2,6 +2,9 @@
 
 namespace LasseRafn\InitialAvatarGenerator;
 
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
+use Intervention\Image\Geometry\Factories\CircleFactory;
 use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
 use LasseRafn\InitialAvatarGenerator\Translator\Base;
@@ -10,6 +13,7 @@ use LasseRafn\InitialAvatarGenerator\Translator\Tr;
 use LasseRafn\InitialAvatarGenerator\Translator\ZhCN;
 use LasseRafn\Initials\Initials;
 use LasseRafn\StringScript;
+use RuntimeException;
 use SVG\Nodes\Shapes\SVGCircle;
 use SVG\Nodes\Shapes\SVGRect;
 use SVG\Nodes\Structures\SVGFont;
@@ -78,7 +82,15 @@ class InitialAvatar
      */
     protected function setupImageManager()
     {
-        $this->image = new ImageManager(['driver' => $this->getDriver()]);
+        $driver = $this->getDriver();
+
+        $driverInstance = match ($driver) {
+            'gd' => new GdDriver(),
+            'imagick' => new ImagickDriver(),
+            default => throw new RuntimeException("Unsupported driver."),
+        };
+
+        $this->image = new ImageManager($driverInstance);
     }
 
     /**
@@ -264,9 +276,9 @@ class InitialAvatar
     }
 
     /**
-     * Set the font file by path or int (1-5).
+     * Set the font file by path.
      *
-     * @param string|int $font
+     * @param string $font
      *
      * @return $this
      */
@@ -517,7 +529,7 @@ class InitialAvatar
     /**
      * Will return the font file parameter.
      *
-     * @return string|int
+     * @return string
      */
     public function getFontFile()
     {
@@ -691,12 +703,21 @@ class InitialAvatar
             $height *= 5;
         }
 
-        $avatar = $image->canvas($width, $height, !$this->getRounded() ? $bgColor : null);
+        $avatar = $image->create($width, $height);
+
+        if (!$this->getRounded()) {
+            $avatar = $avatar->fill($bgColor);
+        }
 
         if ($this->getRounded()) {
-            $avatar = $avatar->circle($width - 2, $width / 2, $height / 2, function ($draw) use ($bgColor) {
-                return $draw->background($bgColor);
-            });
+            $avatar = $avatar->drawCircle(
+                x: $width / 2,
+                y: $height / 2,
+                init: function (CircleFactory $circle) use ($width, $bgColor) {
+                    $circle->radius($width -2);
+                    $circle->background($bgColor);
+                }
+            );
         }
 
         if ($this->getRounded() && $this->getSmooth()) {
@@ -706,7 +727,10 @@ class InitialAvatar
         }
 
         return $avatar->text($name, $width / 2, $height / 2, function ($draw) use ($width, $color, $fontFile, $fontSize) {
-            $draw->file($fontFile);
+            if ($fontFile !== null) {
+                $draw->filename($fontFile);
+            }
+
             $draw->size($width * $fontSize);
             $draw->color($color);
             $draw->align('center');
@@ -755,16 +779,16 @@ class InitialAvatar
         return $image;
     }
 
+
+    /**
+     * @return string|null
+     */
     protected function findFontFile()
     {
         $fontFile = $this->getFontFile();
 
         if ($this->getAutoFont()) {
             $fontFile = $this->getFontByScript();
-        }
-
-        if (is_int($fontFile) && \in_array($fontFile, [1, 2, 3, 4, 5], false)) {
-            return $fontFile;
         }
 
         $weightsToTry = ['Regular'];
@@ -791,7 +815,7 @@ class InitialAvatar
             }
         }
 
-        return 1;
+        return null;
     }
 
     protected function getFontByScript()

--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -50,10 +50,10 @@ class GenerateTest extends TestCase
     {
         $avatar = new InitialAvatar();
 
-        $image = $avatar->font(2)->gd()->generate('LR');
+        $image = $avatar->gd()->generate('LR');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 
     /** @test */
@@ -64,7 +64,7 @@ class GenerateTest extends TestCase
         $image = $avatar->imagick()->generate('LR');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 
     /** @test */
@@ -75,7 +75,7 @@ class GenerateTest extends TestCase
         $image = $avatar->gd()->generate('LR');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 
     /** @test */
@@ -103,7 +103,7 @@ class GenerateTest extends TestCase
     {
         $avatar = new InitialAvatar();
 
-        $this->assertTrue($avatar->generate()->stream()->isReadable());
+        $this->assertNotEmpty($avatar->generate()->toJpeg()->size());
     }
 
     /** @test */

--- a/tests/ImageSizeTest.php
+++ b/tests/ImageSizeTest.php
@@ -12,8 +12,8 @@ class ImageSizeTest extends TestCase
 
         $avatar->size(50);
 
-        $this->assertEquals(50, $avatar->generate()->getWidth());
-        $this->assertEquals(50, $avatar->generate()->getHeight());
+        $this->assertEquals(50, $avatar->generate()->width());
+        $this->assertEquals(50, $avatar->generate()->height());
     }
 
     /** @test */
@@ -23,7 +23,7 @@ class ImageSizeTest extends TestCase
 
         $avatar->size(100);
 
-        $this->assertEquals(100, $avatar->generate()->getWidth());
-        $this->assertEquals(100, $avatar->generate()->getHeight());
+        $this->assertEquals(100, $avatar->generate()->width());
+        $this->assertEquals(100, $avatar->generate()->height());
     }
 }

--- a/tests/ScriptLanguageDetectionTest.php
+++ b/tests/ScriptLanguageDetectionTest.php
@@ -13,7 +13,7 @@ class ScriptLanguageDetectionTest extends TestCase
         $image = $avatar->autoFont()->generate('الحزمة');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 
     /** @test */
@@ -24,7 +24,7 @@ class ScriptLanguageDetectionTest extends TestCase
         $image = $avatar->autoFont()->generate('բենգիմžē');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 
     /** @test */
@@ -35,7 +35,7 @@ class ScriptLanguageDetectionTest extends TestCase
         $image = $avatar->autoFont()->generate('ǰǰô জ');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 
     /** @test */
@@ -46,7 +46,7 @@ class ScriptLanguageDetectionTest extends TestCase
         $image = $avatar->autoFont()->generate('გამარჯობა');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 
     /** @test */
@@ -57,7 +57,7 @@ class ScriptLanguageDetectionTest extends TestCase
         $image = $avatar->autoFont()->generate('ה ו ז ח ט');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 
     /** @test */
@@ -68,7 +68,7 @@ class ScriptLanguageDetectionTest extends TestCase
         $image = $avatar->autoFont()->generate('ᠪᠣᠯᠠᠢ᠃');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 
     /** @test */
@@ -79,7 +79,7 @@ class ScriptLanguageDetectionTest extends TestCase
         $image = $avatar->autoFont()->generate('สวัสดีชาวโลกและยินดีต้อนรับแพ็กเกจนี้');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 
     /** @test */
@@ -90,7 +90,7 @@ class ScriptLanguageDetectionTest extends TestCase
         $image = $avatar->autoFont()->generate('ཀཁཆཇའ');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 
     /** @test */
@@ -101,7 +101,7 @@ class ScriptLanguageDetectionTest extends TestCase
         $image = $avatar->autoFont()->generate('şçğüöı');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 
     /** @test */
@@ -112,6 +112,6 @@ class ScriptLanguageDetectionTest extends TestCase
         $image = $avatar->autoFont()->generate('ψψ');
 
         $this->assertEquals('Intervention\Image\Image', get_class($image));
-        $this->assertTrue($image->stream()->isReadable());
+        $this->assertNotEmpty($image->toJpeg()->size());
     }
 }


### PR DESCRIPTION
- Updated *intervention/image* version to ^3.11;
- Updated PHP version constraints to ^8.1, as the *image* lib requires;
- Dropped support of filenames represented as *int*, as the *image* lib does not support it;
- Fixed tests.

I tested it in app and it worked fine, though maybe more thorough testing is needed.